### PR TITLE
Add regression pytest suite for OxfordComma rule

### DIFF
--- a/tests/behaviour/test_stilyagi_zip_steps.py
+++ b/tests/behaviour/test_stilyagi_zip_steps.py
@@ -91,7 +91,8 @@ def run_stilyagi_zip(repo_root: Path, scenario_state: ScenarioState) -> None:
         "9.9.9-test",
         "--force",
     ]
-    result = subprocess.run(  # FIXME: arguments are repository-controlled in tests. # noqa: S603
+    # NOTE: arguments are repository-controlled in tests.
+    result = subprocess.run(  # noqa: S603
         command,
         cwd=repo_root,
         check=True,
@@ -123,10 +124,12 @@ def archive_has_content(scenario_state: ScenarioState) -> None:
     expected_rule = f"{style_name}/OxfordComma.yml"
     with ZipFile(archive_path) as archive:
         names = set(archive.namelist())
-        assert any(
-            name.endswith(expected_rule) for name in names
-        ), f"Archive missing {expected_rule}"
-        assert any("/config/" in name for name in names), "Archive missing shared config"
+        assert any(name.endswith(expected_rule) for name in names), (
+            f"Archive missing {expected_rule}"
+        )
+        assert any("/config/" in name for name in names), (
+            "Archive missing shared config"
+        )
 
 
 @then("the archive contains a .vale.ini referencing the concordat style")
@@ -204,7 +207,8 @@ def test_stilyagi_zip_cli_errors(tmp_path: Path, repo_root: Path, case: str) -> 
         "zip",
         *args,
     ]
-    result = subprocess.run(  # FIXME: arguments come from controlled fixtures in tests. # noqa: S603
+    # NOTE: arguments come from controlled fixtures in tests.
+    result = subprocess.run(  # noqa: S603
         command,
         cwd=repo_root,
         capture_output=True,
@@ -212,9 +216,7 @@ def test_stilyagi_zip_cli_errors(tmp_path: Path, repo_root: Path, case: str) -> 
         check=False,
     )
 
-    assert result.returncode != 0, (
-        "CLI should fail for the parametrised error scenario"
-    )
+    assert result.returncode != 0, "CLI should fail for the parametrised error scenario"
     assert expected_error in result.stderr, (
         f"CLI stderr should contain {expected_error!r}"
     )

--- a/tests/styles/test_oxford_comma.py
+++ b/tests/styles/test_oxford_comma.py
@@ -1,0 +1,119 @@
+"""Regression tests for the OxfordComma Vale rule."""
+
+from __future__ import annotations
+
+import textwrap
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from test_helpers.valedate import Valedate
+
+
+def test_oxford_comma_flags_serial_comma_omission(
+    concordat_vale: Valedate,
+) -> None:
+    """Vale should flag three-item lists missing the serial comma."""
+    text = "The crate held apples, bananas and cherries."
+
+    diags = concordat_vale.lint(text)
+
+    assert len(diags) == 1, "expected one diagnostic for missing serial comma"
+    diag = diags[0]
+    assert diag.check == "concordat.OxfordComma", "unexpected rule triggered"
+    assert diag.message == "Use the Oxford comma in lists of three or more items.", (
+        "unexpected diagnostic message"
+    )
+    assert diag.severity == "warning", "rule should warn rather than error"
+    assert diag.line == 1, "issue should be reported on the only line"
+
+
+def test_oxford_comma_allows_serial_comma(
+    concordat_vale: Valedate,
+) -> None:
+    """Proper Oxford comma usage must not raise diagnostics."""
+    text = "The crate held apples, bananas, and cherries."
+
+    diags = concordat_vale.lint(text)
+
+    assert diags == [], "expected no diagnostics for correct serial comma"
+
+
+def test_oxford_comma_reports_every_sentence_in_files(
+    concordat_vale: Valedate,
+) -> None:
+    """lint_path should return an alert for each offending sentence in a file."""
+    doc_path = concordat_vale.root / "lists.md"
+    doc_path.write_text(
+        textwrap.dedent(
+            """\
+            The checklist covers power, cooling and networking.
+
+            The summary references design, delivery and adoption.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    results = concordat_vale.lint_path(doc_path)
+
+    assert str(doc_path) in results, "expected lint_path to key by document path"
+    alerts = results[str(doc_path)]
+    assert len(alerts) == 2, "expected two diagnostics for the two sentences"
+    assert {alert.line for alert in alerts} == {1, 3}, "incorrect lines flagged"
+    assert {alert.check for alert in alerts} == {"concordat.OxfordComma"}, (
+        "unexpected rule triggered for file-based linting"
+    )
+
+
+def test_oxford_comma_ignores_code_fenced_examples(
+    concordat_vale: Valedate,
+) -> None:
+    """Code fences should not be linted for prose-only rules."""
+    text = textwrap.dedent(
+        """\
+        ```
+        apples, bananas and cherries
+        ```
+
+        Reference output only.
+        """
+    )
+
+    diags = concordat_vale.lint(text)
+
+    assert diags == [], "expected no diagnostics from code-fenced content"
+
+
+def test_oxford_comma_handles_em_dash_series(
+    concordat_vale: Valedate,
+) -> None:
+    """Lists that trail into an em dash should still be validated."""
+    text = "The menu lists soup, salad and bread—classic fare."
+
+    diags = concordat_vale.lint(text)
+
+    assert len(diags) == 1, "missing comma before em dash should be flagged"
+    assert diags[0].check == "concordat.OxfordComma", "unexpected rule triggered"
+
+
+def test_oxford_comma_flags_parenthetical_series(
+    concordat_vale: Valedate,
+) -> None:
+    """Parenthetical clauses should not suppress missing serial comma alerts."""
+    text = "The report tracks design, delivery and adoption (all quarterly)."
+
+    diags = concordat_vale.lint(text)
+
+    assert len(diags) == 1, "expected diagnostic for parenthetical list"
+    assert diags[0].check == "concordat.OxfordComma", "unexpected rule triggered"
+
+
+def test_oxford_comma_allows_parenthetical_with_serial_comma(
+    concordat_vale: Valedate,
+) -> None:
+    """Parenthetical lists with the Oxford comma should be allowed."""
+    text = "The report tracks design, delivery, and adoption (all quarterly)."
+
+    diags = concordat_vale.lint(text)
+
+    assert diags == [], "expected no diagnostics when comma precedes the conjunction"

--- a/tests/test_stilyagi.py
+++ b/tests/test_stilyagi.py
@@ -59,16 +59,16 @@ def test_package_styles_builds_archive_with_ini_and_files(sample_project: Path) 
     with ZipFile(archive_path) as archive:
         namelist = set(archive.namelist())
         assert ".vale.ini" in namelist, "Missing .vale.ini in archive"
-        assert (
-            "styles/concordat/Rule.yml" in namelist
-        ), "Missing styles/concordat/Rule.yml in archive"
+        assert "styles/concordat/Rule.yml" in namelist, (
+            "Missing styles/concordat/Rule.yml in archive"
+        )
         ini_body = archive.read(".vale.ini").decode("utf-8")
-        assert (
-            "BasedOnStyles = concordat" in ini_body
-        ), "Expected 'BasedOnStyles = concordat' in .vale.ini"
-        assert (
-            "Vocab = concordat" in ini_body
-        ), "Expected 'Vocab = concordat' in .vale.ini"
+        assert "BasedOnStyles = concordat" in ini_body, (
+            "Expected 'BasedOnStyles = concordat' in .vale.ini"
+        )
+        assert "Vocab = concordat" in ini_body, (
+            "Expected 'Vocab = concordat' in .vale.ini"
+        )
 
 
 def test_package_styles_refuses_to_overwrite_without_force(
@@ -123,7 +123,9 @@ def test_package_styles_overwrites_with_force(sample_project: Path) -> None:
         target_glob="*.txt",
         force=True,
     )
-    assert overwritten == archive_path, "Expected overwritten archive path to match the original"
+    assert overwritten == archive_path, (
+        "Expected overwritten archive path to match the original"
+    )
     with ZipFile(overwritten) as archive:
         ini_body = archive.read(".vale.ini").decode("utf-8")
     assert "[*.txt]" in ini_body, "Expected .vale.ini to contain [*.txt]"
@@ -185,7 +187,9 @@ def test_package_styles_omits_vocab_when_multiple_present(
 
     with ZipFile(archive_path) as archive:
         ini_body = archive.read(".vale.ini").decode("utf-8")
-    assert "Vocab =" not in ini_body, "Expected .vale.ini to omit Vocab entries when multiple exist"
+    assert "Vocab =" not in ini_body, (
+        "Expected .vale.ini to omit Vocab entries when multiple exist"
+    )
 
 
 def test_package_styles_respects_ini_styles_path(sample_project: Path) -> None:
@@ -204,9 +208,9 @@ def test_package_styles_respects_ini_styles_path(sample_project: Path) -> None:
 
     with ZipFile(archive_path) as archive:
         names = archive.namelist()
-        assert any(
-            name.startswith("custom_styles/concordat/") for name in names
-        ), "Expected archive to contain files under custom_styles/concordat/"
+        assert any(name.startswith("custom_styles/concordat/") for name in names), (
+            "Expected archive to contain files under custom_styles/concordat/"
+        )
         ini_body = archive.read(".vale.ini").decode("utf-8")
     assert "StylesPath = custom_styles" in ini_body, (
         "Expected .vale.ini to contain 'StylesPath = custom_styles'"

--- a/tests/test_stilyagi_cli.py
+++ b/tests/test_stilyagi_cli.py
@@ -72,7 +72,8 @@ def test_cli_refuses_to_overwrite_without_force(staged_project: Path) -> None:
 
     second = _invoke_cli(*base_args)
     assert second.returncode != 0, (
-        f"Second packaging should fail without --force: {second.stderr or second.stdout}"
+        "Second packaging should fail without --force: "
+        f"{second.stderr or second.stdout}"
     )
     assert "already exists" in second.stderr, (
         f"Expected overwrite warning in stderr: {second.stderr}"


### PR DESCRIPTION
## Summary
- Introduces a pytest suite for the OxfordComma Vale rule
- Covers common and edge-case scenarios (missing serial comma, proper usage, file-based linting, fenced code blocks, em dash, and parentheses)

## Changes
- New tests/styles/test_oxford_comma.py implementing regression tests:
  - test_oxford_comma_flags_serial_comma_omission
  - test_oxford_comma_allows_serial_comma
  - test_oxford_comma_reports_every_sentence_in_files
  - test_oxford_comma_ignores_code_fenced_examples
  - test_oxford_comma_handles_em_dash_series
  - test_oxford_comma_flags_parenthetical_series
  - test_oxford_comma_allows_parenthetical_with_serial_comma
- Minor test style fixes to existing tests for lint compliance:
  - test_stilyagi.py: tightened assertion messages to single-line strings
  - test_stilyagi_cli.py: tightened assertion messages to single-line strings
  - behaviour/test_stilyagi_zip_steps.py: adjusted inline messages/comments to satisfy linters
- No production code changes

## Test plan
- Run the full pytest suite, focusing on:
  - tests/styles/test_oxford_comma.py (7 tests)
  - Existing tests to ensure no regressions are introduced
- Verify lint/style checks pass for updated tests (S603 and related checks)
- Confirm behavior matches expectations for serial comma handling in various contexts

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/33fe45ac-c175-447d-8bfb-71c670cf4cae

## Summary by Sourcery

Introduce a comprehensive pytest regression suite for the OxfordComma Vale rule and update existing tests for lint/style compliance without touching production code

Enhancements:
- Tighten assertion messages and adjust inline comments in existing tests to satisfy lint rules and use single-line messages

Tests:
- Add seven regression tests for the OxfordComma rule covering serial comma omission, correct usage, file-based linting, code-fenced blocks, em dash series, and parenthetical series