### PR TITLE
Add stilyagi install subcommand to pin Concordat release

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,22 @@
 StylesPath = .vale/styles
-MinAlertLevel = suggestion
-Packages = dist/concordat-dev.zip
+Packages = https://github.com/leynos/concordat-vale/releases/download/v0.1.0/concordat-0.1.0.zip
+MinAlertLevel = warning
 Vocab = concordat
 
-[*.{md,adoc,txt}]
+[docs/**/*.{md,markdown,mdx}]
 BasedOnStyles = concordat
+# Ignore for footnotes
+BlockIgnores = (?m)^\[\^\d+\]:[^\n]*(?:\n[ \t]+[^\n]*)*
+
+[AGENTS.md]
+BasedOnStyles = concordat
+
+[*.{rs,ts,js,sh,py}]
+BasedOnStyles = concordat
+concordat.RustNoRun = NO
+concordat.Acronyms = NO
+
+# README.md may use first/second person pronouns
+[README.md]
+BasedOnStyles = concordat
+concordat.Pronouns = NO

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,10 @@ vale-archive: build ## Build the dev Concordat archive for local linting
 vale-sync: vale-archive ## Sync Concordat into .vale/styles
 	$(VALE) sync --config $(VALE_CONFIG)
 
-vale: vale-sync ## Lint docs with Vale after syncing and patching acronyms
-	$(UV_ENV) uv run --script $(ACRONYM_SCRIPT)
-	$(VALE) --config $(VALE_CONFIG) --minAlertLevel suggestion $(VALE_TARGETS)
+.PHONY: vale
+vale: $(VALE) $(ACRONYM_SCRIPT) ## Check prose
+	$(VALE) sync
+	$(VALE) --no-global .
 
 test: build uv $(VENV_TOOLS) ## Run tests
 	$(UV_ENV) uv run pytest -v -n auto

--- a/docs/local-validation-of-github-actions-with-act-and-pytest.md
+++ b/docs/local-validation-of-github-actions-with-act-and-pytest.md
@@ -186,10 +186,10 @@ runtime or socket is unavailable, but to _run_ it you must opt in:
 ACT_WORKFLOW_TESTS=1 sudo -E make test
 ```
 
-That target first runs the regular test suite as the invoking user, then re-runs
-only the workflow harness when `ACT_WORKFLOW_TESTS=1`. After running with sudo,
-remove the root-owned `.venv` (`sudo rm -rf .venv`) so future non-root commands
-can recreate it.
+That target first runs the regular test suite as the invoking user, then
+re-runs only the workflow harness when `ACT_WORKFLOW_TESTS=1`. After running
+with sudo, remove the root-owned `.venv` (`sudo rm -rf .venv`) so future
+non-root commands can recreate it.
 
 ## Record -> replay -> verify (closing the loop)
 

--- a/features/stilyagi_install.feature
+++ b/features/stilyagi_install.feature
@@ -1,0 +1,6 @@
+Feature: Configure Vale to use the latest Concordat release
+  Scenario: Install the latest package into .vale.ini
+    Given a working directory with a Vale config file
+    And a fake GitHub API reporting version 9.9.9
+    When I run stilyagi install for leynos/concordat-vale against that API
+    Then the Vale config lists the Concordat package URL and settings

--- a/test_helpers/valedate.py
+++ b/test_helpers/valedate.py
@@ -324,7 +324,16 @@ class Valedate:
         styles_dir.mkdir(parents=True, exist_ok=True)
         match styles:
             case cabc.Mapping():
-                _materialise_tree(styles_dir, styles)
+                cleaned: dict[str, str | bytes] = {}
+                for rel_path, contents in styles.items():
+                    if not isinstance(contents, (bytes, str)):
+                        msg = (
+                            "styles mapping values must be str or bytes, got "
+                            f"{type(contents).__name__}"
+                        )
+                        raise TypeError(msg)
+                    cleaned[str(rel_path)] = contents
+                _materialise_tree(styles_dir, cleaned)
             case Path():
                 _copy_styles_into(styles_dir, styles)
             case None:

--- a/tests/behaviour/test_stilyagi_install_steps.py
+++ b/tests/behaviour/test_stilyagi_install_steps.py
@@ -1,0 +1,146 @@
+"""Behavioural tests for the stilyagi install subcommand."""
+
+from __future__ import annotations
+
+import http.server
+import json
+import subprocess
+import sys
+import threading
+import typing as typ
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+FEATURE_PATH = (
+    Path(__file__).resolve().parents[2] / "features" / "stilyagi_install.feature"
+)
+
+
+class InstallState(typ.TypedDict, total=False):
+    """Mutable cross-step storage for pytest-bdd scenarios."""
+
+    workspace: Path
+    config_path: Path
+    api_base: str
+
+
+scenarios(str(FEATURE_PATH))
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    """Return the repository root for executing the CLI via python -m."""
+    return Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def scenario_state() -> InstallState:
+    """Provide per-scenario state shared between steps."""
+    return {}
+
+
+@pytest.fixture
+def fake_release_api(tmp_path_factory: pytest.TempPathFactory) -> typ.Iterator[str]:
+    """Expose a minimal GitHub API stub that serves a latest-release payload."""
+    payload = {
+        "tag_name": "v9.9.9",
+        "assets": [
+            {
+                "name": "concordat-9.9.9.zip",
+                "browser_download_url": "http://example.invalid/releases/download/v9.9.9/concordat-9.9.9.zip",
+            }
+        ],
+    }
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/repos/leynos/concordat-vale/releases/latest":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(payload).encode("utf-8"))
+                return
+
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, _fmt: str, *_args: object) -> None:
+            # Silence default logging during tests.
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@given("a working directory with a Vale config file")
+def working_directory(tmp_path: Path, scenario_state: InstallState) -> None:
+    """Create a temporary workspace with an existing .vale.ini."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_path = workspace / ".vale.ini"
+    config_path.write_text(
+        "StylesPath = .vale/styles\nMinAlertLevel = suggestion\n", encoding="utf-8"
+    )
+    scenario_state["workspace"] = workspace
+    scenario_state["config_path"] = config_path
+
+
+@given("a fake GitHub API reporting version 9.9.9")
+def stub_api(fake_release_api: str, scenario_state: InstallState) -> None:
+    """Record the base URL the CLI should target for release metadata."""
+    scenario_state["api_base"] = fake_release_api
+
+
+@when("I run stilyagi install for leynos/concordat-vale against that API")
+def run_install(repo_root: Path, scenario_state: InstallState) -> None:
+    """Execute the install subcommand against the stubbed API."""
+    command = [
+        sys.executable,
+        "-m",
+        "concordat_vale.stilyagi",
+        "install",
+        "leynos/concordat-vale",
+        "--api-base",
+        scenario_state["api_base"],
+        "--config-path",
+        str(scenario_state["config_path"]),
+    ]
+
+    # Arguments are repository-controlled inside the test suite.
+    result = subprocess.run(  # noqa: S603
+        command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        "stilyagi install should succeed:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+@then("the Vale config lists the Concordat package URL and settings")
+def config_contains_expected_lines(scenario_state: InstallState) -> None:
+    """Validate the config file now matches the Concordat defaults."""
+    config_path = scenario_state["config_path"]
+    contents = config_path.read_text(encoding="utf-8")
+
+    assert (
+        "Packages = http://example.invalid/releases/download/v9.9.9/concordat-9.9.9.zip"
+        in contents
+    )
+    assert "MinAlertLevel = warning" in contents
+    assert "Vocab = concordat" in contents
+    assert "[docs/**/*.{md,markdown,mdx}]" in contents
+    assert "BlockIgnores = (?m)^\\[\\^\\d+\\]:" in contents
+    assert "concordat.Pronouns = NO" in contents

--- a/tests/test_stilyagi.py
+++ b/tests/test_stilyagi.py
@@ -72,9 +72,7 @@ def test_package_styles_builds_archive_with_ini_and_files(sample_project: Path) 
     assert "BasedOnStyles" not in ini_body, (
         "Generated .vale.ini should not declare BasedOnStyles entries"
     )
-    assert "Vocab = concordat" in ini_body, (
-        "Expected 'Vocab = concordat' in .vale.ini"
-    )
+    assert "Vocab = concordat" in ini_body, "Expected 'Vocab = concordat' in .vale.ini"
     assert "[*." not in ini_body, (
         "Generated .vale.ini should not define file-targeted sections"
     )

--- a/tests/test_stilyagi_install.py
+++ b/tests/test_stilyagi_install.py
@@ -1,0 +1,155 @@
+"""Unit tests for installing Concordat packages via stilyagi."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+from concordat_vale import stilyagi
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+    from urllib.request import Request
+
+    import pytest
+
+
+class _FakeResponse:
+    """Minimal HTTP response stub for exercising release fetching."""
+
+    def __init__(self, *, status: int, body: dict[str, typ.Any]) -> None:
+        self._status = status
+        self._payload = json.dumps(body).encode("utf-8")
+
+    def read(self) -> bytes:  # pragma: no cover - exercised indirectly
+        return self._payload
+
+    def getcode(self) -> int:
+        return self._status
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _traceback: object,
+    ) -> None:
+        return None
+
+
+def _fake_release(version: str, asset_url: str) -> dict[str, typ.Any]:
+    """Return a GitHub-like release payload for the specified version."""
+    return {
+        "tag_name": f"v{version}",
+        "assets": [
+            {
+                "name": f"concordat-{version}.zip",
+                "browser_download_url": asset_url,
+            }
+        ],
+    }
+
+
+def test_fetch_latest_release_prefers_matching_zip() -> None:
+    """Select the concordat ZIP asset and strip the tag prefix."""
+    captured_headers: dict[str, str] = {}
+
+    def fake_open(request: Request, timeout: int = 10) -> _FakeResponse:
+        # Request objects flow through from urllib so we can inspect headers.
+        accept_header = request.get_header("Accept") or ""
+        auth_header = request.get_header("Authorization") or ""
+        captured_headers.update(
+            {
+                "Accept": accept_header,
+                "Authorization": auth_header,
+            }
+        )
+        return _FakeResponse(
+            status=200,
+            body=_fake_release(
+                version="9.9.9",
+                asset_url="https://downloads.example/concordat-9.9.9.zip",
+            ),
+        )
+
+    fake_token = "-".join(["test", "token"])
+    release = stilyagi._fetch_latest_release(  # type: ignore[attr-defined]
+        "acme/concordat",
+        api_base="https://api.example",
+        token=fake_token,
+        opener=fake_open,
+    )
+
+    assert release.version == "9.9.9"
+    assert release.asset_url.endswith("concordat-9.9.9.zip")
+    assert captured_headers["Accept"].startswith("application/vnd.github+json")
+    assert captured_headers["Authorization"] == f"Bearer {fake_token}"
+
+
+def test_install_rewrites_ini_and_preserves_styles_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Rewrite .vale.ini with Concordat defaults while keeping StylesPath."""
+    existing_ini = tmp_path / ".vale.ini"
+    existing_ini.write_text(
+        "StylesPath = .vale/styles\nMinAlertLevel = suggestion\n", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(
+        stilyagi,
+        "_fetch_latest_release",
+        lambda repo, api_base, token, opener=None: stilyagi.ReleaseInfo(  # type: ignore[attr-defined]
+            tag="v1.2.3",
+            version="1.2.3",
+            asset_url="https://github.com/example/releases/download/v1.2.3/concordat-1.2.3.zip",
+        ),
+    )
+
+    destination = stilyagi.install_styles(
+        repo="example/concordat",
+        config_path=existing_ini,
+        api_base="https://api.example",
+        styles_path=None,
+        token=None,
+    )
+
+    body = destination.read_text(encoding="utf-8")
+    assert body.startswith("StylesPath = .vale/styles\n")
+    assert "MinAlertLevel = warning" in body
+    assert (
+        "Packages = https://github.com/example/releases/download/v1.2.3/concordat-1.2.3.zip"
+        in body
+    )
+    assert "BasedOnStyles = concordat" in body
+    assert "BlockIgnores = (?m)^\\[\\^\\d+\\]:" in body
+    assert "concordat.Pronouns = NO" in body
+
+
+def test_install_defaults_styles_path_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Use a hidden styles directory when no StylesPath is configured."""
+    config_path = tmp_path / ".vale.ini"
+    monkeypatch.setattr(
+        stilyagi,
+        "_fetch_latest_release",
+        lambda repo, api_base, token, opener=None: stilyagi.ReleaseInfo(  # type: ignore[attr-defined]
+            tag="v2.0.0",
+            version="2.0.0",
+            asset_url="https://example.invalid/concordat-2.0.0.zip",
+        ),
+    )
+
+    stilyagi.install_styles(
+        repo="acme/concordat",
+        config_path=config_path,
+        api_base="https://api.example",
+        styles_path=None,
+        token=None,
+    )
+
+    contents = config_path.read_text(encoding="utf-8")
+    assert contents.splitlines()[0] == "StylesPath = .vale/styles"
+    assert "Packages = https://example.invalid/concordat-2.0.0.zip" in contents

--- a/tests/test_vale_packages.py
+++ b/tests/test_vale_packages.py
@@ -6,11 +6,11 @@ import http.server
 import os
 import shutil
 import subprocess
+import textwrap
 import threading
 import typing as typ
 from functools import partial
 from pathlib import Path
-import textwrap
 
 import pytest
 
@@ -192,11 +192,13 @@ def test_vale_lint_succeeds_after_installing_packaged_style(
 
     synced_style = workspace / "styles" / "simple-style" / "SimpleSpelling.yml"
     assert synced_style.exists(), (
-        "vale sync did not install the packaged style at " f"{synced_style}"
+        f"vale sync did not install the packaged style at {synced_style}"
     )
-    synced_vocab = workspace / "styles" / "config" / "vocabularies" / "simple" / "accept.txt"
+    synced_vocab = (
+        workspace / "styles" / "config" / "vocabularies" / "simple" / "accept.txt"
+    )
     assert synced_vocab.exists(), (
-        "vale sync did not unpack the vocabulary file at " f"{synced_vocab}"
+        f"vale sync did not unpack the vocabulary file at {synced_vocab}"
     )
 
     lint_result = _run_vale_lint(sample_doc, env, workspace)


### PR DESCRIPTION
## Summary
- Introduces a new stilyagi install subcommand to automatically fetch the latest Concordat release from GitHub and update the Vale config (.vale.ini).
- Preserves existing StylesPath behavior and supports overrides via token and API base.
- Adds behavioral and unit tests, feature file, and docs updates to describe and validate the new flow.

## Changes

### Core functionality
- Implemented release discovery helpers:
  - _latest_release_url, _strip_tag_prefix, _select_zip_asset, _fetch_latest_release, ReleaseInfo
- Added install_styles to resolve and write the Vale config for the latest release, preserving any existing StylesPath or falling back to .vale/styles.
- Added _existing_styles_path and _render_install_ini to compose the final .vale.ini content.
- Introduced an install workflow that updates the Vale config and returns the path to the updated file.

### CLI
- Added install_command (stilyagi install) with options:
  - repo (owner/repo)
  - --config-path (STILYAGI_CONFIG_PATH)
  - --api-base (STILYAGI_API_BASE)
  - --styles-path (STILYAGI_STYLES_PATH)
  - --token (STILYAGI_TOKEN, or GITHUB_TOKEN)
- Command prints the updated config path and writes the new .vale.ini.

### Packaging and configuration
- The generated .vale.ini contains:
  - StylesPath = <styles_path>
  - Packages = <latest_release_zip_url>
  - MinAlertLevel = warning
  - Vocab = concordat
  - Concordat-focused sections for docs/assets (docs/**/*.{md,markdown,mdx}, AGENTS.md, etc.)
- Keeps existing StylesPath when present; defaults to .vale/styles otherwise.

### Tests
- Added unit tests in tests/test_stilyagi_install.py to verify:
  - _fetch_latest_release selects the correct asset and strips the v prefix
  - install_styles rewrites the ini and preserves StylesPath
  - defaults when StylesPath is missing
- Added behaviour tests in tests/behaviour/test_stilyagi_install_steps.py and feature file features/stilyagi_install.feature to exercise the end-to-end flow using a fake GitHub API.
- Minor test expectation adjustment in tests/test_stilyagi.py to reflect the presence of Vocab = concordat in generated config.

### Documentation
- Updated docs/users-guide.md with a new section: "Installing Concordat with stilyagi install" including workflow, options, and an example generated .vale.ini.

## Test plan
- Run the full test suite: pytest -q
- Specifically verify:
  - Unit tests for fetch/install logic pass
  - Behavioural tests for the install flow pass against a mocked GitHub API
  - The generated .vale.ini contains StylesPath, Packages, MinAlertLevel, Vocab, and Concordat sections as shown in the docs

## Notes
- The implementation uses a GitHub API URL constructed as https://api.github.com/repos/<owner>/<repo>/releases/latest by default, with a configurable api-base for tests.
- Optional authentication via token to handle rate limits; token can come from --token or GITHUB_TOKEN/STILYAGI_TOKEN env vars.



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e3be61f7-96ef-4dc9-920c-6b771b0788f3

## Summary by Sourcery

Add a new install subcommand to automatically discover and pin the latest Concordat release into a Vale configuration file, preserving existing style paths with optional overrides, and back it up with comprehensive docs and tests.

New Features:
- Add `stilyagi install` subcommand to fetch the latest Concordat GitHub release and update the Vale configuration
- Implement release discovery helpers for constructing the API URL, stripping tag prefixes, selecting ZIP assets, and fetching release metadata

Enhancements:
- Preserve existing StylesPath or default to `.vale/styles` when generating the updated `.vale.ini`
- Render a Concordat-focused configuration snippet with pinned Packages URL, warning-level alerts, vocabulary, and targeted file sections
- Support overrides via CLI options and environment variables for repo reference, config path, API base, styles path, and authentication token

Documentation:
- Document the `stilyagi install` workflow, options, and example `.vale.ini` in the user guide and local validation docs

Tests:
- Add unit tests for release fetching and install logic
- Add behavioural tests and a BDD feature for end-to-end validation against a fake GitHub API

Chores:
- Update Makefile to simplify the `vale` target to use `vale sync` and `--no-global`
- Enhance test_helpers valedate to enforce that style mapping values are str or bytes