### PR TITLE
Improve AcronymsFirstUse: ignore composite and joined tokens; add tests

### DIFF
--- a/styles/config/scripts/AcronymsFirstUse.tengo
+++ b/styles/config/scripts/AcronymsFirstUse.tengo
@@ -94,6 +94,7 @@ is_upper := func(ch) { return len(ch) == 1 && ch >= "A" && ch <= "Z" }
 is_lower := func(ch) { return len(ch) == 1 && ch >= "a" && ch <= "z" }
 is_digit := func(ch) { return len(ch) == 1 && ch >= "0" && ch <= "9" }
 is_space := func(ch) { return ch == " " || ch == "\t" || ch == "\n" || ch == "\r" }
+is_joiner := func(ch) { return ch == ":" || ch == ";" || ch == "/" || ch == "-" || ch == "+" }
 
 is_md_rule := func(word) {
   if len(word) < 3 {
@@ -471,6 +472,44 @@ for i < n {
         continue
       }
 
+      prev_idx := -1
+      prev := ""
+      k := i - 1
+      for k >= 0 {
+        prev = s[k:k+1]
+        if is_space(prev) {
+          k -= 1
+          continue
+        }
+        prev_idx = k
+        break
+      }
+
+      if prev_idx != -1 && (is_lower(prev) || is_digit(prev)) {
+        // Skip uppercase fragments welded onto a lowercase prefix (for
+        // example, PyPI or GraphQL).
+        i = j
+        continue
+      }
+
+      next := ""
+      if j < n {
+        next = s[j:j+1]
+      }
+
+      if next != "" && is_joiner(next) && j+1 < n && is_upper(s[j+1:j+2]) {
+        // Ignore composite uppercase tokens split by punctuation (for example,
+        // TL;DR or TLS/SSL) rather than flagging each fragment separately.
+        i = j + 1
+        continue
+      }
+
+      if prev_idx > 0 && is_joiner(prev) && is_upper(s[prev_idx-1:prev_idx]) {
+        // Symmetric handling for the fragment following the punctuation.
+        i = j
+        continue
+      }
+
       base := s[i:j]
 
       skip := 0
@@ -483,17 +522,6 @@ for i < n {
       if is_md_rule(base) && is_in_comment(i) {
         i = j + skip
         continue
-      }
-
-      prev := ""
-      k := i - 1
-      for k >= 0 {
-        prev = s[k:k+1]
-        if is_space(prev) {
-          k -= 1
-          continue
-        }
-        break
       }
 
       if prev == "(" {

--- a/styles/config/scripts/AcronymsFirstUse.tengo
+++ b/styles/config/scripts/AcronymsFirstUse.tengo
@@ -485,9 +485,9 @@ for i < n {
         break
       }
 
-      if prev_idx != -1 && (is_lower(prev) || is_digit(prev)) {
+      if prev_idx == i-1 && (is_lower(prev) || is_digit(prev)) {
         // Skip uppercase fragments welded onto a lowercase prefix (for
-        // example, PyPI or GraphQL).
+        // example, PyPI or GraphQL) when they are immediately adjacent.
         i = j
         continue
       }

--- a/tests/styles/test_acronyms_first_use.py
+++ b/tests/styles/test_acronyms_first_use.py
@@ -17,6 +17,21 @@ def _acronym_diagnostics(concordat_vale: Valedate, text: str) -> list:
     ]
 
 
+def test_acronyms_first_use_flags_unexpanded_acronyms(
+    concordat_vale: Valedate,
+) -> None:
+    """Simple acronyms without definitions should still be reported."""
+    diags = _acronym_diagnostics(
+        concordat_vale,
+        "NASA plans a launch window next month.",
+    )
+
+    assert len(diags) == 1, "expected NASA to require an expansion"
+    diag = diags[0]
+    assert diag.severity == "warning", "AcronymsFirstUse should warn on first use"
+    assert diag.line == 1, "single-line acronym should report on line 1"
+
+
 def test_acronyms_first_use_ignores_composite_tokens(
     concordat_vale: Valedate,
 ) -> None:
@@ -39,3 +54,27 @@ def test_acronyms_first_use_ignores_mixed_case_brand_names(
     )
 
     assert diags == [], "expected PyPI to be ignored by acronym detection"
+
+
+def test_acronyms_first_use_ignores_camelcase_technologies(
+    concordat_vale: Valedate,
+) -> None:
+    """CamelCase technologies like GraphQL should avoid fragment flags."""
+    diags = _acronym_diagnostics(
+        concordat_vale,
+        "GraphQL resolvers validate inputs before forwarding.",
+    )
+
+    assert diags == [], "expected GraphQL to be ignored by acronym detection"
+
+
+def test_acronyms_first_use_ignores_joined_acronyms_split_by_slash(
+    concordat_vale: Valedate,
+) -> None:
+    """Joined acronyms such as TLS/SSL should be treated as one token."""
+    diags = _acronym_diagnostics(
+        concordat_vale,
+        "Renew TLS/SSL certificates before expiry.",
+    )
+
+    assert diags == [], "expected TLS/SSL fragments to be ignored"

--- a/tests/styles/test_acronyms_first_use.py
+++ b/tests/styles/test_acronyms_first_use.py
@@ -1,0 +1,41 @@
+"""Regression tests for the AcronymsFirstUse Vale rule."""
+
+from __future__ import annotations
+
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from valedate import Valedate
+
+
+def _acronym_diagnostics(concordat_vale: Valedate, text: str) -> list:
+    """Return AcronymsFirstUse diagnostics for the provided text."""
+    return [
+        diag
+        for diag in concordat_vale.lint(text)
+        if diag.check == "concordat.AcronymsFirstUse"
+    ]
+
+
+def test_acronyms_first_use_ignores_composite_tokens(
+    concordat_vale: Valedate,
+) -> None:
+    """Composite uppercase words (for example, TL;DR) should pass silently."""
+    diags = _acronym_diagnostics(
+        concordat_vale,
+        "TL;DR: Summarise the change at the top of the note.",
+    )
+
+    assert diags == [], "expected TL;DR to be ignored by acronym detection"
+
+
+def test_acronyms_first_use_ignores_mixed_case_brand_names(
+    concordat_vale: Valedate,
+) -> None:
+    """Mixed-case brand names such as PyPI should not trigger the rule."""
+    diags = _acronym_diagnostics(
+        concordat_vale,
+        "Publish the package to PyPI after tagging.",
+    )
+
+    assert diags == [], "expected PyPI to be ignored by acronym detection"

--- a/tests/styles/test_acronyms_first_use.py
+++ b/tests/styles/test_acronyms_first_use.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import typing as typ
 
 if typ.TYPE_CHECKING:
-    from valedate import Valedate
+    from valedate import Valedate, ValeDiagnostic
 
 
-def _acronym_diagnostics(concordat_vale: Valedate, text: str) -> list:
+def _acronym_diagnostics(concordat_vale: Valedate, text: str) -> list[ValeDiagnostic]:
     """Return AcronymsFirstUse diagnostics for the provided text."""
     return [
         diag
@@ -30,6 +30,19 @@ def test_acronyms_first_use_flags_unexpanded_acronyms(
     diag = diags[0]
     assert diag.severity == "warning", "AcronymsFirstUse should warn on first use"
     assert diag.line == 1, "single-line acronym should report on line 1"
+
+
+def test_acronyms_first_use_flags_mid_sentence_acronym(
+    concordat_vale: Valedate,
+) -> None:
+    """Acronyms following words should still require expansion."""
+    diags = _acronym_diagnostics(
+        concordat_vale,
+        "Visit NASA headquarters for a tour.",
+    )
+
+    assert len(diags) == 1, "expected NASA to require an expansion mid-sentence"
+    assert diags[0].line == 1, "mid-sentence acronym should still report on line 1"
 
 
 def test_acronyms_first_use_ignores_composite_tokens(


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add regression tests ensuring the AcronymsFirstUse rule ignores composite uppercase tokens like TL;DR and joined tokens split by punctuation (e.g., TLS/SSL).
- Add tests ensuring mixed-case brand names such as PyPI are ignored.
- Add tests ensuring CamelCase technologies like GraphQL are ignored.
- Add tests ensuring joined acronyms split by slash (e.g., TLS/SSL) are treated as a single token.

📎 **Task**: https://www.terragonlabs.com/task/63848f6a-b31c-453f-8feb-2ccfe5ccd71b