### PR TITLE
Update OxfordComma rule and expand tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       UV_CACHE_DIR: .uv-cache
       UV_TOOL_DIR: .uv-tools
-      STILYAGI_SOURCE: https://github.com/leynos/stilyagi.git@v0.1.0
+      STILYAGI_SOURCE: git+https://github.com/leynos/stilyagi.git@v0.1.0
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       UV_CACHE_DIR: .uv-cache
       UV_TOOL_DIR: .uv-tools
+      STILYAGI_SOURCE: https://github.com/leynos/stilyagi.git@v0.1.0
     steps:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -116,9 +117,8 @@ jobs:
         id: package
         run: |
           set -euo pipefail
-          uv tool install "stilyagi==0.1.0"
           archive_path="$(
-            stilyagi zip \
+            uvx --from "${STILYAGI_SOURCE}" stilyagi zip \
               --archive-version "${{ steps.meta.outputs.version }}" \
               --force
           )"

--- a/styles/concordat/OxfordComma.yml
+++ b/styles/concordat/OxfordComma.yml
@@ -4,19 +4,14 @@ link: "House style: Oxford comma where it aids comprehension."
 level: warning
 scope: sentence
 nonword: true
-# Heuristic: flag a simple 3-item list lacking the comma before the final
-# 'and/or'. Use verbose, case-insensitive regex for readability and to ensure
-# capitalised subordinators (e.g., 'With', 'Because') are ignored, too.
-tokens:
-  - |
-      (?ix)                     # ignore case, allow comments/whitespace
-      \b
-      [^,]{1,60},\s*           # first item and comma
-      (?!                       # exclude clauses that are not lists
-        \s*(?:with|without|whether|while|when|where|if|unless|
-           until|because|since|which|that|who|whom|whose|and|or|but|so)\b
-      )
-      [^,]{1,60}(?!,)           # second item without trailing comma
-      \s(?:and|or)\s           # coordinator before last item
-      [^,]{1,60}                # final item
-      (?! (?:\)\s+(?:and|or))) # avoid parenthetical follow-ons
+ignorecase: true
+raw:
+  # First item: single word, then comma + space.
+  - '\b[A-Za-z0-9]+,\s+'
+  # Guard against clauses like "X, with Y and Z".
+  - '(?!(?:with|without|whether|while|when|where|if|unless|'
+  - 'until|because|since|which|that|who|whom|whose|so)\b)'
+  # Second and third items: single words with "and/or" between.
+  - '[A-Za-z0-9]+'
+  - '\s+(?:and|or)\s+'
+  - '[A-Za-z0-9]+'

--- a/tests/styles/test_oxford_comma.py
+++ b/tests/styles/test_oxford_comma.py
@@ -40,6 +40,30 @@ def test_oxford_comma_allows_serial_comma(
     assert diags == [], "expected no diagnostics for correct serial comma"
 
 
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        "I like apples, bananas and oranges.",
+        "We value performance, maintainability and readability.",
+        "Define, implement and test the feature.",
+        "The NSA, GCHQ and CSE did something controversial.",
+        "She was tall, strong and silent.",
+        "The function accepts integers, floats or strings.",
+        "Use tabs, spaces or a mix at your own peril.",
+        "The tool checks style, formatting and spelling.",
+        "Our priorities are security, usability and performance.",
+    ],
+)
+def test_oxford_comma_warns_on_simple_lists(
+    concordat_vale: Valedate, sentence: str
+) -> None:
+    """Simple three-item lists without the serial comma should warn once."""
+    diags = concordat_vale.lint(sentence)
+
+    oxford_diags = [diag for diag in diags if diag.check == "concordat.OxfordComma"]
+    assert len(oxford_diags) == 1, "expected a single OxfordComma diagnostic"
+
+
 def test_oxford_comma_reports_every_sentence_in_files(
     concordat_vale: Valedate,
 ) -> None:
@@ -174,9 +198,10 @@ def test_oxford_comma_ignores_relative_clause_after_comma(
     """Relative clauses like ', which/that ...' should not be treated as lists."""
     text = textwrap.dedent(
         f"""
-        The primary goal of this phase is to validate the core architectural decision:
-        using `inventory` for link-time collection of step definitions, {clause_lead} are then
-        discovered and executed by a procedural macro at runtime.
+        The primary goal of this phase is to validate the core architectural
+        decision: using `inventory` for link-time collection of step
+        definitions, {clause_lead} are then discovered and executed by a
+        procedural macro at runtime.
         """
     )
 
@@ -187,7 +212,9 @@ def test_oxford_comma_ignores_relative_clause_after_comma(
     )
 
 
-@pytest.mark.parametrize("clause_lead", ["who", "Who", "whom", "Whom", "whose", "Whose"])
+@pytest.mark.parametrize(
+    "clause_lead", ["who", "Who", "whom", "Whom", "whose", "Whose"]
+)
 def test_oxford_comma_ignores_human_relative_clauses(
     concordat_vale: Valedate, clause_lead: str
 ) -> None:
@@ -210,7 +237,8 @@ def test_oxford_comma_allows_no_space_before_relative_clause(
 ) -> None:
     """Comma-tight relative clauses (,which) should also be exempt."""
     text = (
-        "The module exports alpha, beta,which are then loaded at runtime, without error."
+        "The module exports alpha, beta,which are then loaded at runtime, "
+        "without error."
     )
 
     diags = concordat_vale.lint(text)
@@ -226,8 +254,9 @@ def test_oxford_comma_allows_long_token_before_relative_clause(
     """Long pre-clause tokens should still be exempt after widening limits."""
     text = textwrap.dedent(
         """
-        The especially long introductory phrase containing many descriptive words and clauses,
-        which ultimately still merely sets context, should not be flagged as a list.
+        The especially long introductory phrase containing many descriptive
+        words and clauses, which ultimately still merely sets context, should
+        not be flagged as a list.
         """
     )
 
@@ -235,4 +264,44 @@ def test_oxford_comma_allows_long_token_before_relative_clause(
 
     assert all(diag.check != "concordat.OxfordComma" for diag in diags), (
         "Long pre-clause token should remain exempt from OxfordComma"
+    )
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        (
+            "Unchecked complexity can transform a once-manageable system into a "
+            '"full-blown algorithmic monster," torpedoing performance and '
+            "maintainability."
+        ),
+        (
+            "This reveals that rustdoc's design implicitly prioritizes the "
+            "integrity of the public contract over the convenience of a single, "
+            "unified system for testable documentation of both public and private "
+            "code."
+        ),
+        "I like apples, bananas, and oranges.",
+        "We value performance, maintainability, and readability.",
+        "Define, implement, and test the feature.",
+        "The NSA, GCHQ, and CSE did something controversial.",
+        (
+            "We care about speed, ease of maintenance under changing requirements "
+            "and robustness across environments."
+        ),
+        "They bought red apples, green bananas and a single orange.",
+        "He wrote the report, with style and confidence.",
+        "He tried and failed, and tried again.",
+        "If this fails, try again and log the error.",
+        "Because it was late, we deployed and monitored the change.",
+    ],
+)
+def test_oxford_comma_ignores_non_list_clauses(
+    concordat_vale: Valedate, sentence: str
+) -> None:
+    """Sentences outside the narrow list pattern should not trigger."""
+    diags = concordat_vale.lint(sentence)
+
+    assert all(diag.check != "concordat.OxfordComma" for diag in diags), (
+        "expected no OxfordComma diagnostics for exempt sentences"
     )


### PR DESCRIPTION
## Summary
- Update the OxfordComma style rule to a new raw pattern with case-insensitive matching
- Expand tests to cover warning scenarios, non-list exclusions, and various edge cases
- Align test coverage for relative clauses, long tokens, and wrapped text
- Update release workflow to fetch stilyagi via uvx tool

## Changes
### Style rule
- styles/concordat/OxfordComma.yml
  - Replaced the previous heuristic/token regex with a raw pattern approach
  - Added ignorecase: true and a set of raw patterns to detect simple three-item lists lacking the serial comma while guarding against non-list contexts (e.g., clauses introduced by with/without/because, etc.)
  - Focuses on simple list structures (word, comma, word, and/or word) to trigger OxfordComma diagnostics appropriately

### Tests
- tests/styles/test_oxford_comma.py
  - Added test_oxford_comma_warns_on_simple_lists to ensure a single OxfordComma diagnostic is produced for simple three-item lists missing the serial comma
  - Added test_oxford_comma_ignores_non_list_clauses to ensure sentences outside the narrow list pattern do not trigger diagnostics
  - Expanded existing tests to verify wrapping and relative-clause handling, and to ensure long tokens are exempt where appropriate
  - Updated several tests to reflect new formatting and edge-case handling (e.g., line-wrapping changes, clause leads such as Who/Whom/Whose, and near-relative clauses)

### CI / Release workflow
- .github/workflows/release.yml
  - Introduced STILYAGI_SOURCE environment variable for external tooling versioning
  - Switched to using uvx to fetch and zip stilyagi from the specified source instead of the direct stilyagi tool invocation
  - This aligns the release process with the uvx-based workflow

## Testing plan
- Run unit tests for styles:
  - pytest tests/styles/test_oxford_comma.py
- Verify no regressions in existing OxfordComma behavior with updated rule
- Validate CI pipeline completes with the updated release workflow (uvx-based) and environment variable in place

## Notes
- The OxfordComma rule now relies on a more explicit raw pattern approach, which aims to be clearer and more maintainable than the previous token-based heuristic.
- Tests were expanded to ensure that both warnings and non-warnings are correctly emitted under a variety of sentence structures.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/079cd08b-27c2-46d3-85cd-3d8811643e86

## Summary by Sourcery

Refine the OxfordComma style rule to use a clearer raw-pattern matcher and align tests and release workflow with the updated behavior and tooling.

Enhancements:
- Rework the OxfordComma rule to use a case-insensitive raw pattern targeting simple three-item lists while excluding common non-list clauses.
- Expand OxfordComma test coverage to include simple list warnings, non-list exemptions, wrapped text, and long-token relative clause edge cases.

Deployment:
- Update the release workflow to source stilyagi via uvx and a configurable STILYAGI_SOURCE reference instead of a pinned tool install.

Tests:
- Add new OxfordComma tests for simple three-item lists without a serial comma and for sentences that should be exempt from diagnostics.